### PR TITLE
Add Strategy List and Detail

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,7 +8,7 @@ import { MuiThemeProvider } from '@material-ui/core'
 import theme from 'theme'
 import 'styles/app.styl'
 
-import { Home, Login, Register } from 'pages'
+import { Home, Login, Register, Strategies } from 'pages'
 import { NavBar } from 'shared/components'
 
 const App = () => {
@@ -20,6 +20,7 @@ const App = () => {
           <Route exact path="/" component={Home} />
           <Route path="/login" component={Login} />
           <Route path="/register" component={Register} />
+          <Route path="/strategies" component={Strategies} />
         </BrowserRouter>
       </Provider>
     </MuiThemeProvider>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,7 +8,7 @@ import { MuiThemeProvider } from '@material-ui/core'
 import theme from 'theme'
 import 'styles/app.styl'
 
-import { Home, Login, Register, Strategies } from 'pages'
+import { Home, Login, Register, Strategies, Strategy } from 'pages'
 import { NavBar } from 'shared/components'
 
 const App = () => {
@@ -20,7 +20,8 @@ const App = () => {
           <Route exact path="/" component={Home} />
           <Route path="/login" component={Login} />
           <Route path="/register" component={Register} />
-          <Route path="/strategies" component={Strategies} />
+          <Route path="/strategies" exact component={Strategies} />
+          <Route path="/strategies/:id" component={Strategy} />
         </BrowserRouter>
       </Provider>
     </MuiThemeProvider>

--- a/src/features/strategies/components/StrategyCard.tsx
+++ b/src/features/strategies/components/StrategyCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Strategy } from 'features/strategies/store'
+import { Link } from 'react-router-dom'
 import { Button, Card, CardActions, CardContent, CardMedia, Typography } from '@material-ui/core'
 
 interface StrategyCardProps {
@@ -27,7 +28,9 @@ const StrategyCard = ({ strategy }: StrategyCardProps) => (
       </Typography>
     </CardContent>
     <CardActions>
-      <Button size="small">View Strategy</Button>
+      <Button size="small" component={Link} to={`/strategies/${strategy.id}`}>
+        View Strategy
+      </Button>
     </CardActions>
   </Card>
 )

--- a/src/features/strategies/components/StrategyCard.tsx
+++ b/src/features/strategies/components/StrategyCard.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Strategy } from 'features/strategies/store'
+import { Button, Card, CardActions, CardContent, CardMedia, Typography } from '@material-ui/core'
+
+interface StrategyCardProps {
+  strategy: Strategy
+}
+
+const StrategyCard = ({ strategy }: StrategyCardProps) => (
+  <Card className="strategy-card">
+    <CardContent>
+      <Typography variant="overline" color="textSecondary" gutterBottom>
+        Strategy
+      </Typography>
+      <Typography variant="h5" component="h2">
+        {strategy.title}
+      </Typography>
+    </CardContent>
+    <CardMedia
+      className="strategy-card__media"
+      image="https://flagpedia.net/data/flags/normal/af.png"
+      title={strategy.title}
+    />
+    <CardContent>
+      <Typography variant="body2" color="textSecondary" component="p">
+        {strategy.description}
+      </Typography>
+    </CardContent>
+    <CardActions>
+      <Button size="small">View Strategy</Button>
+    </CardActions>
+  </Card>
+)
+
+export default StrategyCard

--- a/src/features/strategies/components/StrategyDetail.tsx
+++ b/src/features/strategies/components/StrategyDetail.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { getData, getError, StrategiesState, Strategy } from 'features/strategies/store'
+import { Button, CircularProgress, Typography } from '@material-ui/core'
+import { useStrategyData } from 'features/strategies/components/hooks'
+import { useSelector } from 'react-redux'
+
+interface StrategyDetailProps {
+  id: Strategy.id
+}
+
+const StrategyDetail = ({ id }: StrategyDetailProps) => {
+  useStrategyData()
+  const error: StrategiesState.error = useSelector(getError)
+  const strategies: StrategiesState.data = useSelector(getData)
+  const strategy: Strategy | null = strategies ? strategies[id] : null
+
+  if (!error && !strategies) return <CircularProgress />
+  if (error) return <div>{error.detail}</div>
+  if (!strategy) return <div>Could not find Strategy with id {id}</div>
+
+  return (
+    <div className="strategy-detail">
+      <Typography variant="overline" className="strategy-detail__preheading">
+        Strategy: Afghanistan
+      </Typography>
+      <Typography variant="h3" className="strategy-detail__heading">
+        {strategy.title}
+      </Typography>
+      <Typography variant="h5" className="strategy-detail__subheading">
+        Analysis
+      </Typography>
+      <Typography variant="body1" className="strategy-detail__description">
+        {strategy.description}
+      </Typography>
+      <Button color="primary" variant="contained">
+        Show complete analysis
+      </Button>
+    </div>
+  )
+}
+
+export default StrategyDetail

--- a/src/features/strategies/components/StrategyGrid.tsx
+++ b/src/features/strategies/components/StrategyGrid.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { useStrategyData } from './hooks'
+import { getData, getError, StrategiesState } from '../store'
+import { CircularProgress, Grid } from '@material-ui/core'
+import StrategyCard from 'features/strategies/components/StrategyCard'
+
+const StrategyGrid = (): JSX.Element => {
+  useStrategyData()
+  const error: StrategiesState.error = useSelector(getError)
+  const strategies: StrategiesState.data = useSelector(getData)
+
+  if (!error && !strategies) return <CircularProgress />
+  if (error) return <div>{error.detail}</div>
+  if (!strategies) return <div>No Strategies could be found.</div>
+
+  return (
+    <Grid container direction="row" justify="center" alignItems="flex-start">
+      {Object.keys(strategies).map(id => {
+        return <StrategyCard key={id} strategy={strategies[id]} />
+      })}
+    </Grid>
+  )
+}
+
+export default StrategyGrid

--- a/src/features/strategies/components/StrategyGrid.tsx
+++ b/src/features/strategies/components/StrategyGrid.tsx
@@ -15,9 +15,13 @@ const StrategyGrid = (): JSX.Element => {
   if (!strategies) return <div>No Strategies could be found.</div>
 
   return (
-    <Grid container direction="row" justify="center" alignItems="flex-start">
+    <Grid container direction="row" justify="flex-start" alignItems="flex-start" spacing={2}>
       {Object.keys(strategies).map(id => {
-        return <StrategyCard key={id} strategy={strategies[id]} />
+        return (
+          <Grid item key={id}>
+            <StrategyCard strategy={strategies[id]} />
+          </Grid>
+        )
       })}
     </Grid>
   )

--- a/src/features/strategies/components/hooks.ts
+++ b/src/features/strategies/components/hooks.ts
@@ -1,0 +1,14 @@
+import { useDispatch, useSelector } from 'react-redux'
+import { getLoadingState, loadAll, loadingState } from '../store'
+import { useEffect } from 'react'
+
+export const useStrategyData = () => {
+  const currentLoadingState = useSelector(getLoadingState)
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    if (currentLoadingState === loadingState.none) {
+      dispatch(loadAll())
+    }
+  }, [currentLoadingState])
+}

--- a/src/features/strategies/index.ts
+++ b/src/features/strategies/index.ts
@@ -1,0 +1,4 @@
+import StrategyGrid from 'features/strategies/components/StrategyGrid'
+export * from './store'
+
+export { StrategyGrid }

--- a/src/features/strategies/index.ts
+++ b/src/features/strategies/index.ts
@@ -1,4 +1,5 @@
-import StrategyGrid from 'features/strategies/components/StrategyGrid'
+import StrategyGrid from './components/StrategyGrid'
+import StrategyDetail from './components/StrategyDetail'
 export * from './store'
 
-export { StrategyGrid }
+export { StrategyGrid, StrategyDetail }

--- a/src/features/strategies/store/actions.ts
+++ b/src/features/strategies/store/actions.ts
@@ -1,0 +1,47 @@
+import { Strategy } from './types'
+import { ApiError, Endpoints, get } from 'service'
+import { registerRequestAction } from 'store/middleware'
+
+export const STRATEGIES_REQUEST = 'strategies/request'
+export const STRATEGIES_SUCCESS = 'strategies/success'
+export const STRATEGIES_ERROR = 'strategies/error'
+
+interface StrategiesRequest {
+  type: typeof STRATEGIES_REQUEST
+}
+
+interface StrategiesSuccess {
+  type: typeof STRATEGIES_SUCCESS
+  strategies: Strategy[]
+}
+
+interface StrategiesError {
+  type: typeof STRATEGIES_ERROR
+  error: Error
+}
+
+export type StrategiesAction = StrategiesRequest | StrategiesSuccess | StrategiesError
+
+/** Strategies Actions */
+export const loadAll = (() => {
+  const type = STRATEGIES_REQUEST
+  registerRequestAction({
+    type,
+    request: () => get(Endpoints.strategies),
+    onSuccess: (strategies: Strategy[], dispatch) => dispatch(strategiesSuccess(strategies)),
+    onError: (err: ApiError, dispatch) => dispatch(strategiesError(err)),
+  })
+  return (): StrategiesRequest => ({
+    type,
+  })
+})()
+
+const strategiesSuccess = (strategies: Strategy[]): StrategiesSuccess => ({
+  type: STRATEGIES_SUCCESS,
+  strategies,
+})
+
+const strategiesError = (error: ApiError): StrategiesError => ({
+  type: STRATEGIES_ERROR,
+  error,
+})

--- a/src/features/strategies/store/index.ts
+++ b/src/features/strategies/store/index.ts
@@ -1,0 +1,3 @@
+export * from './actions'
+export * from './selectors'
+export * from './types'

--- a/src/features/strategies/store/reducer.ts
+++ b/src/features/strategies/store/reducer.ts
@@ -1,0 +1,36 @@
+import { STRATEGIES_SUCCESS, STRATEGIES_ERROR, STRATEGIES_REQUEST, StrategiesAction } from './actions'
+import { loadingState, StrategiesState } from './types'
+import { toIndexedObject } from 'shared/utils'
+
+const initialState: StrategiesState = {
+  loading: loadingState.none,
+  error: null,
+}
+
+export const strategies = (state: StrategiesState = initialState, action: StrategiesAction): StrategiesState => {
+  switch (action.type) {
+    case STRATEGIES_REQUEST:
+      return {
+        ...state,
+        loading: loadingState.pending,
+      }
+    case STRATEGIES_SUCCESS:
+      return {
+        ...state,
+        loading: loadingState.done,
+        error: null,
+        data: {
+          ...state.data,
+          ...toIndexedObject(action.strategies, 'id'),
+        },
+      }
+    case STRATEGIES_ERROR:
+      return {
+        ...state,
+        loading: loadingState.failed,
+        error: action.error,
+      }
+    default:
+      return state
+  }
+}

--- a/src/features/strategies/store/selectors.ts
+++ b/src/features/strategies/store/selectors.ts
@@ -1,0 +1,5 @@
+const slice = 'strategies'
+
+export const getLoadingState = state => state[slice].loading
+export const getError = state => state[slice].error
+export const getData = state => state[slice].data

--- a/src/features/strategies/store/types.ts
+++ b/src/features/strategies/store/types.ts
@@ -1,0 +1,23 @@
+export enum loadingState {
+  none = 'NONE',
+  pending = 'PENDING',
+  done = 'DONE',
+  failed = 'FAILED',
+}
+
+export interface StrategiesState {
+  loading: loadingState
+  error?: object
+  data: { [key: Strategy.id]: Strategy }
+}
+
+export interface Strategy {
+  id: number
+  user: number
+  title: string
+  description: string
+  measures: Array<number>
+  is_published: boolean
+  created: Date
+  updated: Date
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 
 export default function Home(): JSXElement {
   return (
     <>
       <h1>Space for awesome stuff...</h1>
+      <Link to="/strategies">Strategies</Link>
     </>
   )
 }

--- a/src/pages/Strategies.tsx
+++ b/src/pages/Strategies.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { StrategyGrid } from 'features/strategies'
+import { Typography } from '@material-ui/core'
+
+const Strategies = () => (
+  <div className="strategy-page">
+    <Typography variant="h3" className="strategy-page__heading">
+      Strategies
+    </Typography>
+    <Typography variant="body1" className="strategy-page__description">
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+      dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita
+      kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
+      sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+      voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
+      sanctus est Lorem ipsum dolor sit amet.
+    </Typography>
+    <Typography variant="h5" className="strategy-page__subheading">
+      Countries
+    </Typography>
+    <StrategyGrid />
+  </div>
+)
+
+export default Strategies

--- a/src/pages/Strategy.tsx
+++ b/src/pages/Strategy.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { useParams } from 'react-router-dom'
+import { StrategyDetail } from 'features/strategies'
+
+const Strategy = () => {
+  const { id } = useParams()
+  return (
+    <div className="strategy-detail-page">
+      <StrategyDetail id={id} />
+    </div>
+  )
+}
+
+export default Strategy

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,5 +1,6 @@
 import Home from './Home'
 import Login from './Login'
 import Register from './Register'
+import Strategies from './Strategies'
 
-export { Home, Login, Register }
+export { Home, Login, Register, Strategies }

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -2,5 +2,6 @@ import Home from './Home'
 import Login from './Login'
 import Register from './Register'
 import Strategies from './Strategies'
+import Strategy from './Strategy'
 
-export { Home, Login, Register, Strategies }
+export { Home, Login, Register, Strategies, Strategy }

--- a/src/service/api.ts
+++ b/src/service/api.ts
@@ -8,6 +8,7 @@ export enum Endpoints {
   register = 'auth/register',
   login = 'auth/login',
   logout = 'auth/logout',
+  strategies = 'strategies',
 }
 
 enum HttpMethod {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,0 +1,5 @@
+export const toIndexedObject = (array: object[], index) =>
+  array.reduce((acc, curr) => {
+    acc[curr[index]] = curr
+    return acc
+  }, {})

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -2,10 +2,12 @@ import { combineReducers } from 'redux'
 
 import { registration } from 'features/registration/store/reducer'
 import { authentication } from 'features/authentication/store/reducer'
+import { strategies } from 'features/strategies/store/reducer'
 
 const reducers = {
   authentication,
   registration,
+  strategies,
 }
 
 const rootReducer = combineReducers(reducers)

--- a/src/styles/components/StrategyCard.styl
+++ b/src/styles/components/StrategyCard.styl
@@ -1,0 +1,5 @@
+.strategy-card
+  width 300px
+
+  &__media
+    height 200px

--- a/src/styles/pages/Strategies.styl
+++ b/src/styles/pages/Strategies.styl
@@ -1,0 +1,2 @@
+.strategy-page
+  padding 30px

--- a/src/styles/pages/Strategies.styl
+++ b/src/styles/pages/Strategies.styl
@@ -1,2 +1,4 @@
 .strategy-page
   padding 30px
+  &__subheading
+    margin-bottom 20px !important

--- a/src/styles/pages/Strategy.styl
+++ b/src/styles/pages/Strategy.styl
@@ -1,0 +1,2 @@
+.strategy-detail-page
+  padding 30px

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -15,6 +15,14 @@ export default createMuiTheme({
       contrastText: '#000',
     },
   },
+  typography: {
+    h3: {
+      marginBottom: defaultTheme.spacing(2),
+    },
+    body1: {
+      marginBottom: defaultTheme.spacing(3),
+    },
+  },
   overrides: {
     MuiTextField: {
       root: {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -30,11 +30,5 @@ export default createMuiTheme({
         marginBottom: defaultTheme.spacing(1),
       },
     },
-    MuiButton: {
-      root: {
-        marginTop: defaultTheme.spacing(2),
-        marginBottom: defaultTheme.spacing(2),
-      },
-    },
   },
 })


### PR DESCRIPTION
Added the strategy feature, including a list (grid) and a detail view.

Please note, that it's currently not yet possible to connect a strategy to it's corresponding country (or get information about it's creator), therefore all strategies are listed as belonging to Afghanistan. It also wasn't clear to me how to determine the one official strategy of a country, so as of now, all strategies of a country are still listed.