### PR TITLE
Add redirect rules for Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
To let our SPA handle all the routings we must tell netlify to forward all request to any subpaths to our index. This ensures that a user can reload or directly navigate to any page that is not the index page, without getting an error, as it's currently the case.