### PR TITLE
Fix: Only show entities related to current strategy

### DIFF
--- a/src/features/strategies/components/block/BlockDetail.tsx
+++ b/src/features/strategies/components/block/BlockDetail.tsx
@@ -1,19 +1,31 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { getBlock, Block } from 'features/strategies/store'
-import { CategoryGrid, useBlockData } from 'features/strategies/components'
+import { getBlock, Block, Strategy, getStrategy } from 'features/strategies/store'
+import { CategoryGrid, useBlockData, useStrategyData } from 'features/strategies/components'
 import { StandardView } from 'shared/components'
 
 interface BlockDetailProps {
-  id: Block['id']
+  blockId: Block['id']
+  strategyId: Strategy['id']
 }
 
-const BlockDetail = ({ id }: BlockDetailProps) => {
+const BlockDetail = ({ blockId, strategyId }: BlockDetailProps) => {
   useBlockData()
-  const block = useSelector(getBlock(id))
-  if (!block) return <div>Could not find Block with id {id}</div>
+  useStrategyData()
 
-  const renderCategoryGrid = () => <CategoryGrid ids={block.categories} />
+  const block = useSelector(getBlock(blockId))
+  const strategy = useSelector(getStrategy(strategyId))
+
+  if (!(block && strategy))
+    return (
+      <div>
+        Could not find Block with id {blockId} on Strategy with id {strategyId}
+      </div>
+    )
+
+  const categoryIds = block.categories.filter(category => strategy.categories.includes(category))
+  const renderCategoryGrid = () => <CategoryGrid ids={categoryIds} />
+
   return (
     <StandardView
       title={block.title}

--- a/src/features/strategies/components/category/CategoryDetail.tsx
+++ b/src/features/strategies/components/category/CategoryDetail.tsx
@@ -1,19 +1,31 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { getCategory, Category } from 'features/strategies/store'
-import { useCategoryData, SituationGrid } from 'features/strategies/components'
+import { getCategory, Category, Strategy, getStrategy } from 'features/strategies/store'
+import { useCategoryData, SituationGrid, useStrategyData } from 'features/strategies/components'
 import { StandardView } from 'shared/components'
 
 interface CategoryDetailProps {
-  id: Category['id']
+  categoryId: Category['id']
+  strategyId: Strategy['id']
 }
 
-const CategoryDetail = ({ id }: CategoryDetailProps) => {
+const CategoryDetail = ({ categoryId, strategyId }: CategoryDetailProps) => {
   useCategoryData()
-  const category = useSelector(getCategory(id))
-  if (!category) return <div>Could not find Category with id {id}</div>
+  useStrategyData()
 
-  const renderSituationGrid = () => <SituationGrid ids={category.situations} />
+  const category = useSelector(getCategory(categoryId))
+  const strategy = useSelector(getStrategy(strategyId))
+
+  if (!(category && strategy))
+    return (
+      <div>
+        Could not find Category with id {categoryId} on Strategy with id {strategyId}
+      </div>
+    )
+
+  const situationIds = category.situations.filter(situation => strategy.situations.includes(situation))
+  const renderSituationGrid = () => <SituationGrid ids={situationIds} />
+
   return (
     <StandardView
       title={category.title}

--- a/src/features/strategies/components/situation/SituationDetail.tsx
+++ b/src/features/strategies/components/situation/SituationDetail.tsx
@@ -1,19 +1,31 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { getSituation, Situation } from 'features/strategies/store'
-import { MeasureGrid, useSituationData } from 'features/strategies/components'
+import { getSituation, getStrategy, Situation, Strategy } from 'features/strategies/store'
+import { MeasureGrid, useSituationData, useStrategyData } from 'features/strategies/components'
 import { StandardView } from 'shared/components'
 
 interface SituationDetailProps {
-  id: Situation['id']
+  situationId: Situation['id']
+  strategyId: Strategy['id']
 }
 
-const SituationDetail = ({ id }: SituationDetailProps) => {
+const SituationDetail = ({ situationId, strategyId }: SituationDetailProps) => {
   useSituationData()
-  const situation = useSelector(getSituation(id))
-  if (!situation) return <div>Could not find Situation with id {id}</div>
+  useStrategyData()
 
-  const renderMeasureGrid = () => <MeasureGrid ids={situation.measures} />
+  const situation = useSelector(getSituation(situationId))
+  const strategy = useSelector(getStrategy(strategyId))
+
+  if (!(situation && strategy))
+    return (
+      <div>
+        Could not find Situation with id {situationId} on Strategy with id {strategyId}
+      </div>
+    )
+
+  const measureIds = situation.measures.filter(measure => strategy.measures.includes(measure))
+  const renderMeasureGrid = () => <MeasureGrid ids={measureIds} />
+
   return (
     <StandardView
       title={situation.title}

--- a/src/pages/Block.tsx
+++ b/src/pages/Block.tsx
@@ -4,8 +4,10 @@ import { BlockDetail } from 'features/strategies/components'
 import { APP_ROUTE_PARAMS } from 'app/routes'
 
 const Block = () => {
-  const { [APP_ROUTE_PARAMS.blockId]: blockId } = useParams<typeof APP_ROUTE_PARAMS>()
-  return blockId ? <BlockDetail id={+blockId} /> : null
+  const params = useParams<typeof APP_ROUTE_PARAMS>()
+  const { [APP_ROUTE_PARAMS.strategyId]: strategyId, [APP_ROUTE_PARAMS.blockId]: blockId } = params
+
+  return blockId ? <BlockDetail strategyId={+strategyId} blockId={+blockId} /> : null
 }
 
 export default Block

--- a/src/pages/Category.tsx
+++ b/src/pages/Category.tsx
@@ -4,8 +4,10 @@ import { CategoryDetail } from 'features/strategies/components'
 import { APP_ROUTE_PARAMS } from 'app/routes'
 
 const Category = () => {
-  const { [APP_ROUTE_PARAMS.categoryId]: categoryId } = useParams<typeof APP_ROUTE_PARAMS>()
-  return categoryId ? <CategoryDetail id={+categoryId} /> : null
+  const params = useParams<typeof APP_ROUTE_PARAMS>()
+  const { [APP_ROUTE_PARAMS.strategyId]: strategyId, [APP_ROUTE_PARAMS.categoryId]: categoryId } = params
+
+  return categoryId ? <CategoryDetail strategyId={+strategyId} categoryId={+categoryId} /> : null
 }
 
 export default Category

--- a/src/pages/Situation.tsx
+++ b/src/pages/Situation.tsx
@@ -4,8 +4,10 @@ import { SituationDetail } from 'features/strategies/components'
 import { APP_ROUTE_PARAMS } from 'app/routes'
 
 const Situation = () => {
-  const { [APP_ROUTE_PARAMS.situationId]: situationId } = useParams<typeof APP_ROUTE_PARAMS>()
-  return situationId ? <SituationDetail id={+situationId} /> : null
+  const params = useParams<typeof APP_ROUTE_PARAMS>()
+  const { [APP_ROUTE_PARAMS.strategyId]: strategyId, [APP_ROUTE_PARAMS.situationId]: situationId } = params
+
+  return situationId ? <SituationDetail strategyId={+strategyId} situationId={+situationId} /> : null
 }
 
 export default Situation


### PR DESCRIPTION
When viewing a strategy all building-blocks, categories, situations and measures have been shown, even though they might not have been related to the strategy at all. This PR fixes this bug.