### PR TITLE
Fix Strategy Types to match new API

### DIFF
--- a/src/features/strategies/store/actions.strategies.ts
+++ b/src/features/strategies/store/actions.strategies.ts
@@ -1,7 +1,7 @@
-import { Country, Strategy, User } from './types'
+import { Country, Strategy } from './types'
 import { Endpoint, get } from 'app/service'
 import { createRequest } from 'features/requests/store'
-import { CountryResponse, StrategyResponse, UserResponse } from 'features/strategies/store/types.api'
+import { CountryResponse, StrategyResponse } from 'features/strategies/store/types.api'
 
 export const STRATEGIES_REQUEST_ID = 'strategies'
 export const STRATEGIES_ADD = 'strategies/add'
@@ -27,10 +27,9 @@ const addStrategies = (strategies: Strategy[]): StrategiesAdd => ({
 })
 
 const transformResponseData = (strategies: StrategyResponse[]): Strategy[] => {
-  return strategies.map(({ user, country, buildingBlocks, situationCategories, created, updated, ...strategy }) => ({
+  return strategies.map(({ board, buildingBlocks, situationCategories, created, updated, ...strategy }) => ({
     ...strategy,
-    user: transformUserData(user),
-    country: transformCountryData(country),
+    country: transformCountryData(board.country),
     blocks: buildingBlocks,
     categories: situationCategories,
     created: new Date(created),
@@ -39,25 +38,25 @@ const transformResponseData = (strategies: StrategyResponse[]): Strategy[] => {
 }
 
 // TODO: should be defined elsewhere
-const transformUserData = ({
-  firstname,
-  lastname,
-  country,
-  currentCountry,
-  created,
-  updated,
-  ...user
-}: UserResponse): User => {
-  return {
-    ...user,
-    firstName: firstname,
-    lastName: lastname,
-    country: country ? transformCountryData(country) : null,
-    currentCountry: currentCountry ? transformCountryData(currentCountry) : null,
-    created: new Date(created),
-    updated: new Date(updated),
-  }
-}
+// const transformUserData = ({
+//   firstname,
+//   lastname,
+//   country,
+//   currentCountry,
+//   created,
+//   updated,
+//   ...user
+// }: UserResponse): User => {
+//   return {
+//     ...user,
+//     firstName: firstname,
+//     lastName: lastname,
+//     country: country ? transformCountryData(country) : null,
+//     currentCountry: currentCountry ? transformCountryData(currentCountry) : null,
+//     created: new Date(created),
+//     updated: new Date(updated),
+//   }
+// }
 
 // TODO: should be defined elsewhere
 const transformCountryData = ({ created, updated, ...country }: CountryResponse): Country => {

--- a/src/features/strategies/store/types.api.ts
+++ b/src/features/strategies/store/types.api.ts
@@ -4,8 +4,7 @@
 
 export interface StrategyResponse {
   id: number
-  user: UserResponse
-  country: CountryResponse
+  board: BoardResponse
   title: string
   description: string
   isPublished: boolean
@@ -14,6 +13,15 @@ export interface StrategyResponse {
   situationCategories: CategoryResponse['id'][]
   situations: SituationResponse['id'][]
   measures: MeasureResponse['id'][]
+  created: string
+  updated: string
+}
+
+//TODO: should be defined elsewhere
+export interface BoardResponse {
+  id: number
+  country: CountryResponse
+  users: UserResponse[]
   created: string
   updated: string
 }

--- a/src/features/strategies/store/types.ts
+++ b/src/features/strategies/store/types.ts
@@ -9,7 +9,6 @@ export interface StrategiesState {
 
 export interface Strategy {
   id: number
-  user: User
   country: Country
   title: string
   description: string


### PR DESCRIPTION
When viewing strategies the changes to the API caused a Type-Error. This is a temporary fix, that enables the correct displaying of the strategies. The error when creating/editing a strategy will be addressed in another PR.