### PR TITLE
Fix Strategy breadcrumbs

### DIFF
--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -16,7 +16,6 @@ import {
   Discussion,
   Thread,
   ThreadNew,
-  UserProfile,
   AccountInfo,
 } from 'pages'
 
@@ -28,7 +27,7 @@ import {
   SituationBreadcrumb,
 } from 'features/strategies'
 import { AnalysisBreadcrumb } from 'features/analyses'
-import { DiscussionBreadcrumb } from '../features/discussions/components/DiscussionBreadcrumb'
+import { DiscussionBreadcrumb } from 'features/discussions/components/DiscussionBreadcrumb'
 
 export const APP_ROUTE_PARAMS: { [key: string]: string } = {
   analysisId: 'analysisId',
@@ -43,28 +42,35 @@ const p = APP_ROUTE_PARAMS
 
 export const APP_ROUTES = {
   home: '/',
+
+  /** Account */
   login: '/login',
   register: '/register',
+  account: '/account',
+
+  /** Analyses */
   analyses: '/analyses',
   analysis: `/analyses/:${p.analysisId}`,
+
+  /** Strategies */
   strategies: '/strategies',
   strategy: `/strategies/:${p.strategyId}`,
   block: `/strategies/:${p.strategyId}/:${p.blockId}`,
   category: `/strategies/:${p.strategyId}/:${p.blockId}/:${p.categoryId}`,
   situation: `/strategies/:${p.strategyId}/:${p.blockId}/:${p.categoryId}/:${p.situationId}`,
   measure: `/strategies/:${p.strategyId}/:${p.blockId}/:${p.categoryId}/:${p.situationId}/:${p.measureId}`,
-  education: '/education',
-  infrastructure: '/infrastructure',
-  management: '/management',
-  discussions: '/discussions',
-  discussion: '/discussions/:strategyId',
-  newThread: '/discussions/:strategyId/new-thread',
-  thread: '/discussions/:strategyId/threads/:threadId',
-  account: '/account',
+
+  /** Strategy Editor */
   editor: {
     create: `/strategies/add/:${p.boardId}`,
     update: `/strategies/edit/:${p.boardId}`,
   },
+
+  /** Discussions */
+  discussions: '/discussions',
+  discussion: '/discussions/:strategyId',
+  newThread: '/discussions/:strategyId/new-thread',
+  thread: '/discussions/:strategyId/threads/:threadId',
 }
 
 export const routes: RouteConfig[] = [
@@ -74,6 +80,8 @@ export const routes: RouteConfig[] = [
     exact: true,
     breadcrumb: null,
   },
+
+  /** Account */
   {
     path: APP_ROUTES.login,
     component: Login,
@@ -86,18 +94,23 @@ export const routes: RouteConfig[] = [
     path: APP_ROUTES.account,
     component: AccountInfo,
   },
-  {
-    path: Object.values(APP_ROUTES.editor),
-    component: StrategyEditor,
-  },
-  {
-    path: APP_ROUTES.strategies,
-    component: Strategies,
-    exact: true,
-  },
+
+  /** Analyses */
   {
     path: APP_ROUTES.analyses,
     component: Analyses,
+    exact: true,
+  },
+  {
+    path: APP_ROUTES.analysis,
+    component: Analysis,
+    breadcrumb: AnalysisBreadcrumb,
+  },
+
+  /** Strategies */
+  {
+    path: APP_ROUTES.strategies,
+    component: Strategies,
     exact: true,
   },
   {
@@ -130,6 +143,14 @@ export const routes: RouteConfig[] = [
     exact: true,
     breadcrumb: MeasureBreadcrumb,
   },
+
+  /** Strategy Editor */
+  {
+    path: Object.values(APP_ROUTES.editor),
+    component: StrategyEditor,
+  },
+
+  /** Discussions */
   {
     path: APP_ROUTES.discussions,
     component: Discussions,
@@ -152,16 +173,5 @@ export const routes: RouteConfig[] = [
     exact: true,
     component: ThreadNew,
     // breadcrumb: MeasureBreadcrumb, // TODO
-  },
-  {
-    path: APP_ROUTES.analysis,
-    component: Analysis,
-    exact: true,
-    breadcrumb: AnalysisBreadcrumb,
-  },
-  {
-    path: APP_ROUTES.account,
-    component: UserProfile,
-    exact: true,
   },
 ]

--- a/src/features/strategies/components/strategy/StrategyGrid.tsx
+++ b/src/features/strategies/components/strategy/StrategyGrid.tsx
@@ -3,14 +3,18 @@ import { useSelector } from 'react-redux'
 import { useStrategyData } from 'features/strategies/components/hooks'
 import { getStrategies } from 'features/strategies/store'
 import { CountryGrid } from 'features/countries/components'
-import { APP_ROUTE_PARAMS, APP_ROUTES } from 'app/routes'
 import { Country } from 'features/countries/store'
 
 interface StrategyGridProps {
-  linkTo?: typeof APP_ROUTES.strategy | typeof APP_ROUTES.discussion
+  linkTo?: string
 }
 
-const StrategyGrid = ({ linkTo = APP_ROUTES.strategy }: StrategyGridProps): JSX.Element => {
+//TODO: somehow using APP_ROUTES and APP_ROUTE_PARAMS here, breaks breadcrumb for all strategy pages.
+// Might be an issue with circular dependencies?
+const defaultRoute = '/strategies/:strategyId' //APP_ROUTES.strategy
+const routeParam = ':strategyId' //APP_ROUTE_PARAMS.strategyId
+
+const StrategyGrid = ({ linkTo = defaultRoute }: StrategyGridProps): JSX.Element => {
   useStrategyData()
   const strategies = Object.values(useSelector(getStrategies) || {})
   const countryIds = strategies.filter(strategy => strategy.isPublished).map(strategy => strategy.country.id)
@@ -20,7 +24,7 @@ const StrategyGrid = ({ linkTo = APP_ROUTES.strategy }: StrategyGridProps): JSX.
 
   const getStrategyRoute = (countryId: Country['id']) => {
     const strategyId = getStrategyByCountryId(countryId)?.id
-    if (strategyId) return linkTo.replace(`:${APP_ROUTE_PARAMS.strategyId}`, String(strategyId))
+    if (strategyId) return linkTo.replace(routeParam, String(strategyId))
     else return ''
   }
 


### PR DESCRIPTION
With #49 the breadcrumbs on all strategy pages did not display their titles correctly anymore, but only the ids. This might be due to an issue with circular dependencies in the Breadcrumb components, but honestly I did not really understand why it happened. I fixed it, by directly declaring the strings again in the StrategyGrid component. This is not a good solution, but it works. If anyone has any other idea on how to fix this I'd be happy to use that one instead.