### PR TITLE
Fix missing strategyMeasures in StrategyEditor

### DIFF
--- a/src/features/strategy-editor/components/hooks.ts
+++ b/src/features/strategy-editor/components/hooks.ts
@@ -35,5 +35,5 @@ export const useSetInitialStrategyEditorValues = (strategyId: StrategyDraft['id'
       dispatch(setFields({ title: '', description: '', isPublished: false }))
       dispatch(setMeasures([]))
     }
-  }, [strategy])
+  }, [strategy, allStrategyMeasures])
 }


### PR DESCRIPTION
When opening the strategy editor for editing an existing strategy, without visiting the strategy or discussion section first, the strategyMeasures were missing. This happened, because if the strategyMeasures needed to be fetched first, the editor component did not react to the state changes later on.